### PR TITLE
Various improvements and ruggedizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ dkms.conf
 # Python
 __pycache__
 *.pyc
+.venv
+Pipfile.lock
 
 * CLion and/or PyCharm IDEs
 .idea

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+ipython = "*"
+
+[packages]
+cryptography = "*"
+colorama = "*"
+pynacl = "*"

--- a/README.md
+++ b/README.md
@@ -93,6 +93,81 @@ use the cryptography module.
 Building
 ========
 
+libsodium C examples
+--------------------
+
+The [libsodium](https://download.libsodium.org/doc/) C code examples are all in the **sodium** directory and can be 
+built using the [Cmake](https://cmake.org) cross-platform build tool along with your platform default C compiler
+installed on Windows, macOS, or Linux.
+
+The first stage of building is the same on all platforms:
+
+```bash
+cd sodium
+rm -rf build
+mkdir build
+cd build
+cmake ..
+```
+
+The second stage of building is platform dependent and will create the following executable files:
+
+* hello_sodium
+* nacl_keygen
+* nacl_sign
+* nacl_verify
+* symmetric_decrypt
+* symmetric_encrypt
+* symmetric_keygen
+* test_ed25519
+* test_pynacl_compatibility
+
+### Linux or macOS
+```bash
+make
+```
+
+This produces the  executable files directly in the **build** directory.
+
+### Windows
+```bash
+devenv hello_sodium.sln /build Debug
+```
+This creates the executable files under the **build\Debug** directory.
+
+Python examples
+---------------
+
+The Python examples are located in the root directory and should work with Python 3.4 or newer.  The Python examples 
+require a mix of the following Python packages:
+
+* [cryptography](https://cryptography.io/en/latest/) - high-level wrapper around [OpenSSL](https://www.openssl.org)
+* [pynacl](https://pynacl.readthedocs.io/en/stable/) - Python binding to [libsodium](https://libsodium.org)
+* [colorama](https://github.com/tartley/colorama) - cross-platform colored terminal text
+
+The required dependencies can easily be installed using [Pipenv](https://github.com/pypa/pipenv):
+```shell script
+pipenv install
+```
+
+Then a shell using the underlying virtual environment can be entered with:
+```shell script
+pipenv shell
+```
+
+Inside that Pipenv shell, any of the examples can be ran directly. e.g.:
+```shell script
+python ./aes_gcm_cryptography.py
+```
+
+The Python examples are intended to interoperate with either the libsodium or mbedTLS C code examples.  Thus encryption
+or signing can be done in C and decryption or verifying can be done in Python or vice versa.
+
+mbedtls C examples
+------------------
+The [mbedTLS](https://github.com/ARMmbed/mbedtls) C code examples are located in the root directory and build mbedTLS
+from source from the **mbedtls** directory.
+
 Build requires CMake and platform default C compiler installed and works on both Windows, macOS, and Linux.
 
 The first stage of building is the same on all platforms:
@@ -106,8 +181,7 @@ cmake ..
 
 The second stage of building is platform dependent ...
 
-Linux or macOS
---------------
+### Linux or macOS
 ```bash
 make
 ```
@@ -120,8 +194,7 @@ This produces the following executable files directly in the **build** directory
 * kdf
 * rsa_signature
 
-Windows
--------
+### Windows
 ```bash
 devenv mbed_AES.sln /build Debug
 ```

--- a/sodium/CMakeLists.txt
+++ b/sodium/CMakeLists.txt
@@ -5,8 +5,16 @@ project("hello_sodium" C)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -O2 -Wall")
 
+# Set the CMAKE_MODULE_PATH so it can find the Findsodium.cmake file
+set(CMAKE_MODULE_PATH
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+        ${CMAKE_MODULE_PATH})
+
 # Projects which statically link Sodium in Visual Studio must define a macro named SODIUM_STATIC
 add_definitions(-DSODIUM_STATIC)
+
+# Find where libsodium is installed (prevent linker errors)
+find_package(sodium REQUIRED)
 
 # Tell CMake where to look for header files
 include_directories(${CMAKE_SOURCE_DIR}/include)

--- a/sodium/cmake/Findsodium.cmake
+++ b/sodium/cmake/Findsodium.cmake
@@ -1,0 +1,294 @@
+# Written in 2016 by Henrik Steffen Gaßmann <henrik@gassmann.onl>
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+#
+#     http://creativecommons.org/publicdomain/zero/1.0/
+#
+########################################################################
+# Tries to find the local libsodium installation.
+#
+# On Windows the sodium_DIR environment variable is used as a default
+# hint which can be overridden by setting the corresponding cmake variable.
+#
+# Once done the following variables will be defined:
+#
+#   sodium_FOUND
+#   sodium_INCLUDE_DIR
+#   sodium_LIBRARY_DEBUG
+#   sodium_LIBRARY_RELEASE
+#
+#
+# Furthermore an imported "sodium" target is created.
+#
+
+if (CMAKE_C_COMPILER_ID STREQUAL "GNU"
+        OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    set(_GCC_COMPATIBLE 1)
+endif()
+
+# static library option
+if (NOT DEFINED sodium_USE_STATIC_LIBS)
+    option(sodium_USE_STATIC_LIBS "enable to statically link against sodium" OFF)
+endif()
+if(NOT (sodium_USE_STATIC_LIBS EQUAL sodium_USE_STATIC_LIBS_LAST))
+    unset(sodium_LIBRARY CACHE)
+    unset(sodium_LIBRARY_DEBUG CACHE)
+    unset(sodium_LIBRARY_RELEASE CACHE)
+    unset(sodium_DLL_DEBUG CACHE)
+    unset(sodium_DLL_RELEASE CACHE)
+    set(sodium_USE_STATIC_LIBS_LAST ${sodium_USE_STATIC_LIBS} CACHE INTERNAL "internal change tracking variable")
+endif()
+
+
+########################################################################
+# UNIX
+if (UNIX)
+    # import pkg-config
+    find_package(PkgConfig QUIET)
+    if (PKG_CONFIG_FOUND)
+        pkg_check_modules(sodium_PKG QUIET libsodium)
+    endif()
+
+    if(sodium_USE_STATIC_LIBS)
+        foreach(_libname ${sodium_PKG_STATIC_LIBRARIES})
+            if (NOT _libname MATCHES "^lib.*\\.a$") # ignore strings already ending with .a
+                list(INSERT sodium_PKG_STATIC_LIBRARIES 0 "lib${_libname}.a")
+            endif()
+        endforeach()
+        list(REMOVE_DUPLICATES sodium_PKG_STATIC_LIBRARIES)
+
+        # if pkgconfig for libsodium doesn't provide
+        # static lib info, then override PKG_STATIC here..
+        if (NOT sodium_PKG_STATIC_FOUND)
+            set(sodium_PKG_STATIC_LIBRARIES libsodium.a)
+        endif()
+
+        set(XPREFIX sodium_PKG_STATIC)
+    else()
+        if (NOT sodium_PKG_FOUND)
+            set(sodium_PKG_LIBRARIES sodium)
+        endif()
+
+        set(XPREFIX sodium_PKG)
+    endif()
+
+    find_path(sodium_INCLUDE_DIR sodium.h
+            HINTS ${${XPREFIX}_INCLUDE_DIRS}
+            )
+    find_library(sodium_LIBRARY_DEBUG NAMES ${${XPREFIX}_LIBRARIES}
+            HINTS ${${XPREFIX}_LIBRARY_DIRS}
+            )
+    find_library(sodium_LIBRARY_RELEASE NAMES ${${XPREFIX}_LIBRARIES}
+            HINTS ${${XPREFIX}_LIBRARY_DIRS}
+            )
+
+
+    ########################################################################
+    # Windows
+elseif (WIN32)
+    set(sodium_DIR "$ENV{sodium_DIR}" CACHE FILEPATH "sodium install directory")
+    mark_as_advanced(sodium_DIR)
+
+    find_path(sodium_INCLUDE_DIR sodium.h
+            HINTS ${sodium_DIR}
+            PATH_SUFFIXES include
+            )
+
+    if (MSVC)
+        # detect target architecture
+        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/arch.cpp" [=[
+            #if defined _M_IX86
+            #error ARCH_VALUE x86_32
+            #elif defined _M_X64
+            #error ARCH_VALUE x86_64
+            #endif
+            #error ARCH_VALUE unknown
+        ]=])
+        try_compile(_UNUSED_VAR "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/arch.cpp"
+                OUTPUT_VARIABLE _COMPILATION_LOG
+                )
+        string(REGEX REPLACE ".*ARCH_VALUE ([a-zA-Z0-9_]+).*" "\\1" _TARGET_ARCH "${_COMPILATION_LOG}")
+
+        # construct library path
+        if (_TARGET_ARCH STREQUAL "x86_32")
+            string(APPEND _PLATFORM_PATH "Win32")
+        elseif(_TARGET_ARCH STREQUAL "x86_64")
+            string(APPEND _PLATFORM_PATH "x64")
+        else()
+            message(FATAL_ERROR "the ${_TARGET_ARCH} architecture is not supported by Findsodium.cmake.")
+        endif()
+        string(APPEND _PLATFORM_PATH "/$$CONFIG$$")
+
+        if (MSVC_VERSION LESS 1900)
+            math(EXPR _VS_VERSION "${MSVC_VERSION} / 10 - 60")
+        else()
+            math(EXPR _VS_VERSION "${MSVC_VERSION} / 10 - 50")
+        endif()
+        string(APPEND _PLATFORM_PATH "/v${_VS_VERSION}")
+
+        if (sodium_USE_STATIC_LIBS)
+            string(APPEND _PLATFORM_PATH "/static")
+        else()
+            string(APPEND _PLATFORM_PATH "/dynamic")
+        endif()
+
+        string(REPLACE "$$CONFIG$$" "Debug" _DEBUG_PATH_SUFFIX "${_PLATFORM_PATH}")
+        string(REPLACE "$$CONFIG$$" "Release" _RELEASE_PATH_SUFFIX "${_PLATFORM_PATH}")
+
+        find_library(sodium_LIBRARY_DEBUG libsodium.lib
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES ${_DEBUG_PATH_SUFFIX}
+                )
+        find_library(sodium_LIBRARY_RELEASE libsodium.lib
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES ${_RELEASE_PATH_SUFFIX}
+                )
+        if (NOT sodium_USE_STATIC_LIBS)
+            set(CMAKE_FIND_LIBRARY_SUFFIXES_BCK ${CMAKE_FIND_LIBRARY_SUFFIXES})
+            set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
+            find_library(sodium_DLL_DEBUG libsodium
+                    HINTS ${sodium_DIR}
+                    PATH_SUFFIXES ${_DEBUG_PATH_SUFFIX}
+                    )
+            find_library(sodium_DLL_RELEASE libsodium
+                    HINTS ${sodium_DIR}
+                    PATH_SUFFIXES ${_RELEASE_PATH_SUFFIX}
+                    )
+            set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_BCK})
+        endif()
+
+    elseif(_GCC_COMPATIBLE)
+        if (sodium_USE_STATIC_LIBS)
+            find_library(sodium_LIBRARY_DEBUG libsodium.a
+                    HINTS ${sodium_DIR}
+                    PATH_SUFFIXES lib
+                    )
+            find_library(sodium_LIBRARY_RELEASE libsodium.a
+                    HINTS ${sodium_DIR}
+                    PATH_SUFFIXES lib
+                    )
+        else()
+            find_library(sodium_LIBRARY_DEBUG libsodium.dll.a
+                    HINTS ${sodium_DIR}
+                    PATH_SUFFIXES lib
+                    )
+            find_library(sodium_LIBRARY_RELEASE libsodium.dll.a
+                    HINTS ${sodium_DIR}
+                    PATH_SUFFIXES lib
+                    )
+
+            file(GLOB _DLL
+                    LIST_DIRECTORIES false
+                    RELATIVE "${sodium_DIR}/bin"
+                    "${sodium_DIR}/bin/libsodium*.dll"
+                    )
+            find_library(sodium_DLL_DEBUG ${_DLL} libsodium
+                    HINTS ${sodium_DIR}
+                    PATH_SUFFIXES bin
+                    )
+            find_library(sodium_DLL_RELEASE ${_DLL} libsodium
+                    HINTS ${sodium_DIR}
+                    PATH_SUFFIXES bin
+                    )
+        endif()
+    else()
+        message(FATAL_ERROR "this platform is not supported by FindSodium.cmake")
+    endif()
+
+
+    ########################################################################
+    # unsupported
+else()
+    message(FATAL_ERROR "this platform is not supported by FindSodium.cmake")
+endif()
+
+
+########################################################################
+# common stuff
+
+# extract sodium version
+if (sodium_INCLUDE_DIR)
+    set(_VERSION_HEADER "${_INCLUDE_DIR}/sodium/version.h")
+    if (EXISTS _VERSION_HEADER)
+        file(READ "${_VERSION_HEADER}" _VERSION_HEADER_CONTENT)
+        string(REGEX REPLACE ".*#[ \t]*define[ \t]*SODIUM_VERSION_STRING[ \t]*\"([^\n]*)\".*" "\\1"
+                sodium_VERSION "${_VERSION_HEADER_CONTENT}")
+        set(sodium_VERSION "${sodium_VERSION}" PARENT_SCOPE)
+    endif()
+endif()
+
+# communicate results
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+        Sodium # The name must be either uppercase or match the filename case.
+        REQUIRED_VARS
+        sodium_LIBRARY_RELEASE
+        sodium_LIBRARY_DEBUG
+        sodium_INCLUDE_DIR
+        VERSION_VAR
+        sodium_VERSION
+)
+
+if(Sodium_FOUND)
+    set(sodium_LIBRARIES
+            optimized ${sodium_LIBRARY_RELEASE} debug ${sodium_LIBRARY_DEBUG})
+endif()
+
+# mark file paths as advanced
+mark_as_advanced(sodium_INCLUDE_DIR)
+mark_as_advanced(sodium_LIBRARY_DEBUG)
+mark_as_advanced(sodium_LIBRARY_RELEASE)
+if (WIN32)
+    mark_as_advanced(sodium_DLL_DEBUG)
+    mark_as_advanced(sodium_DLL_RELEASE)
+endif()
+
+# create imported target
+if(sodium_USE_STATIC_LIBS)
+    set(_LIB_TYPE STATIC)
+else()
+    set(_LIB_TYPE SHARED)
+endif()
+add_library(sodium ${_LIB_TYPE} IMPORTED)
+
+set_target_properties(sodium PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${sodium_INCLUDE_DIR}"
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        )
+
+if (sodium_USE_STATIC_LIBS)
+    set_target_properties(sodium PROPERTIES
+            INTERFACE_COMPILE_DEFINITIONS "SODIUM_STATIC"
+            IMPORTED_LOCATION "${sodium_LIBRARY_RELEASE}"
+            IMPORTED_LOCATION_DEBUG "${sodium_LIBRARY_DEBUG}"
+            )
+else()
+    if (UNIX)
+        set_target_properties(sodium PROPERTIES
+                IMPORTED_LOCATION "${sodium_LIBRARY_RELEASE}"
+                IMPORTED_LOCATION_DEBUG "${sodium_LIBRARY_DEBUG}"
+                )
+    elseif (WIN32)
+        set_target_properties(sodium PROPERTIES
+                IMPORTED_IMPLIB "${sodium_LIBRARY_RELEASE}"
+                IMPORTED_IMPLIB_DEBUG "${sodium_LIBRARY_DEBUG}"
+                )
+        if (NOT (sodium_DLL_DEBUG MATCHES ".*-NOTFOUND"))
+            set_target_properties(sodium PROPERTIES
+                    IMPORTED_LOCATION_DEBUG "${sodium_DLL_DEBUG}"
+                    )
+        endif()
+        if (NOT (sodium_DLL_RELEASE MATCHES ".*-NOTFOUND"))
+            set_target_properties(sodium PROPERTIES
+                    IMPORTED_LOCATION_RELWITHDEBINFO "${sodium_DLL_RELEASE}"
+                    IMPORTED_LOCATION_MINSIZEREL "${sodium_DLL_RELEASE}"
+                    IMPORTED_LOCATION_RELEASE "${sodium_DLL_RELEASE}"
+                    )
+        endif()
+    endif()
+endif()

--- a/sodium/nacl_encrypt_file.c
+++ b/sodium/nacl_encrypt_file.c
@@ -15,6 +15,12 @@
  * Like Salsa20, XSalsa20 is immune to timing attacks and provides its own 64-bit block counter to avoid incrementing
  * the nonce after each block. But with XSalsa20's longer nonce, it is safe to generate nonces using randombytes_buf()
  * for every message encrypted with the same key without having to worry about a collision.
+ *
+ * WARNING:
+ *  This example encrypts the entire file in one shot and only works when everything can fit in your computer's RAM.
+ *  For very large files which cannot fit in your computer's memory, then stream-based encryption is required; for more
+ *  info see the following:
+ *  https://download.libsodium.org/doc/secret-key_cryptography/secretstream#file-encryption-example-code
  */
 
 // A project using libsodium should include the sodium.h header.
@@ -136,6 +142,8 @@ int main(int argc, char *argv[])
     // Allocate buffers big enough to hold the message and the authenticated ciphertext
     unsigned long long message_len = filesize;
     unsigned long long ciphertext_len = crypto_secretbox_MACBYTES + message_len;
+
+    // WARNING: This code makes the assumption that the file can fit in memory and doesn't check for malloc failure
     message = (unsigned char*)malloc(message_len + 1);
     ciphertext = (unsigned char*)malloc(ciphertext_len + 1);
 
@@ -160,7 +168,7 @@ int main(int argc, char *argv[])
     printf("Encrypting message and computing an authentication tag ...");
     ret = crypto_secretbox_easy(ciphertext, message, message_len, nonce, key);
     if ( ret != 0)
-    {   // The only way I can see for this function to fail is if the message length is too large (> 2^64 - 16)
+    {   // This can fail if the message is too large to fit in your computer's memory
         printf(" failed.  Message length = %lld\n", message_len);
     }
     printf(" Done\n");


### PR DESCRIPTION
Improvements include the following:
- Include Pipfile for easily setting a Pipenv virtual environment for running the Python examples
- Improved README build instructions for libsodium and Python examples
- Ruggedized libsodium CMake build to help prevent linker errors on some platforms
- Improved comments in nacl_encrypt_file.c libsodium file encryption example to warn that it is suitable only for files which can fit in the computer's RAM and a stream-based encryption should be used for larger files

Closes #1 